### PR TITLE
refactor: clean up unused imports

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,9 +5,8 @@ FastAPI application providing REST endpoints for the STORM UI frontend.
 Implements file-based storage for projects and integrates with STORM pipeline.
 """
 
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
 import os
 from contextlib import asynccontextmanager
 

--- a/backend/routers/projects.py
+++ b/backend/routers/projects.py
@@ -4,9 +4,8 @@ Projects router for STORM UI API.
 Provides CRUD endpoints for managing STORM projects with file-based storage.
 """
 
-from fastapi import APIRouter, HTTPException, Query, BackgroundTasks
+from fastapi import APIRouter, HTTPException, Query
 from typing import List, Optional, Dict, Any
-from uuid import UUID
 from pydantic import BaseModel, Field
 import logging
 


### PR DESCRIPTION
## Summary
- remove unused BackgroundTasks and FileResponse imports from main app
- drop unused BackgroundTasks and UUID imports from projects router

## Testing
- `python -m black backend/main.py backend/routers/projects.py`
- `pre-commit run --files backend/main.py backend/routers/projects.py` *(failed: RuntimeError: failed to find interpreter for python3.11)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest backend/test_api.py backend/test_google_search.py` *(failed: ConnectionError: HTTPConnectionPool; TypeError: ForwardRef._evaluate missing argument)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ec4dd7ec8332bd2ea10f1e94922a