### PR TITLE
Fix backend imports and stabilize tests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from fastapi.responses import FileResponse
 import os
 from contextlib import asynccontextmanager
 
-from routers import projects, pipeline, docs, settings, models
+from .routers import projects, pipeline, docs, settings, models
 
 
 @asynccontextmanager

--- a/backend/routers/config.py
+++ b/backend/routers/config.py
@@ -8,13 +8,13 @@ from fastapi import APIRouter, HTTPException, Query
 from typing import Dict, Any, Optional
 from pydantic import BaseModel
 
-from services.config_service import (
+from ..services.config_service import (
     ConfigurationService,
     ProjectConfig,
     ConfigLevel,
     get_config_service,
 )
-from services.llm_config_builder import LLMConfigBuilder
+from ..services.llm_config_builder import LLMConfigBuilder
 
 router = APIRouter(prefix="/api/config", tags=["configuration"])
 
@@ -179,7 +179,7 @@ async def get_provider_models(provider: str):
     # Special handling for Ollama - fetch models dynamically
     if provider == "ollama":
         import requests
-        from services.config_service import get_config_service
+        from ..services.config_service import get_config_service
 
         try:
             # Get Ollama configuration

--- a/backend/routers/models.py
+++ b/backend/routers/models.py
@@ -4,7 +4,7 @@ Router for LLM model management endpoints
 
 from fastapi import APIRouter, HTTPException, Query
 from typing import Optional, Dict, List
-from services.llm_service import llm_service, LLMProvider, LLMModel
+from ..services.llm_service import llm_service, LLMProvider, LLMModel
 import logging
 
 logger = logging.getLogger(__name__)

--- a/backend/routers/pipeline.py
+++ b/backend/routers/pipeline.py
@@ -17,8 +17,8 @@ import asyncio
 import json
 import logging
 
-from services.file_service import FileProjectService, ProjectConfig, ProgressData
-from services.storm_runner import StormRunnerService
+from ..services.file_service import FileProjectService, ProjectConfig, ProgressData
+from ..services.storm_runner import StormRunnerService
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/backend/routers/projects.py
+++ b/backend/routers/projects.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 from uuid import UUID
 import logging
 
-from services.file_service import FileProjectService, ProjectConfig
+from ..services.file_service import FileProjectService, ProjectConfig
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/backend/services/file_service.py
+++ b/backend/services/file_service.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field
 import uuid
-from services.config_service import ProjectConfig
+from .config_service import ProjectConfig
 
 
 class ProjectMetadata(BaseModel):

--- a/backend/test_config_update.py
+++ b/backend/test_config_update.py
@@ -1,101 +1,51 @@
-#!/usr/bin/env python3
-"""Test script to verify configuration update works correctly."""
+"""Tests for updating project configuration without running the API server."""
 
-import requests
-import json
-import sys
+from __future__ import annotations
 
-# Test with a known project ID
-PROJECT_ID = "6e6c267a-df92-4ce2-9516-9deb4dda71f5"
-API_URL = "http://localhost:8000/api"
+from backend.services.file_service import FileProjectService
+from backend.services.config_service import ProjectConfig, PipelineConfig, RetrieverConfig
 
 
-def test_config_update():
-    """Test updating project configuration with specific pipeline settings disabled."""
+def test_config_update(tmp_path):
+    """Verify that project configuration updates are persisted on disk."""
 
-    # Configuration with some pipeline stages disabled
-    test_config = {
-        "config_version": "1.0.0",
-        "llm": {
-            "provider": "openai",
-            "model": "gpt-4o",
-            "temperature": 0.7,
-            "max_tokens": 4000,
-        },
-        "retriever": {
-            "retriever_type": "tavily",
-            "max_search_results": 10,
-            "search_top_k": 3,
-        },
-        "pipeline": {
-            "do_research": False,  # Disabled
-            "do_generate_outline": True,
-            "do_generate_article": False,  # Disabled
-            "do_polish_article": True,
-            "max_conv_turn": 3,
-            "max_perspective": 4,
-            "max_search_queries_per_turn": 3,
-        },
-        "output": {"output_format": "markdown", "include_citations": True},
-    }
+    # Use an isolated temporary directory for project storage
+    storage_dir = tmp_path / "projects"
+    service = FileProjectService(base_path=str(storage_dir))
 
-    print(f"Updating config for project {PROJECT_ID}...")
-    print(f"Setting do_research={test_config['pipeline']['do_research']}")
-    print(
-        f"Setting do_generate_article={test_config['pipeline']['do_generate_article']}"
+    # Create a project with default configuration
+    project_summary = service.create_project(
+        title="Config Persistence", topic="Testing configuration storage"
+    )
+    project_id = project_summary["id"]
+
+    # Build a configuration that disables some pipeline stages and switches retriever
+    updated_config = ProjectConfig(
+        retriever=RetrieverConfig(retriever_type="tavily", max_search_results=10),
+        pipeline=PipelineConfig(
+            do_research=False,
+            do_generate_outline=True,
+            do_generate_article=False,
+            do_polish_article=True,
+            max_conv_turn=3,
+            max_perspective=4,
+            max_search_queries_per_turn=3,
+        ),
     )
 
-    # Send the update request
-    response = requests.put(
-        f"{API_URL}/projects/{PROJECT_ID}/config",
-        json=test_config,
-        headers={"Content-Type": "application/json"},
-    )
+    # Persist the configuration and ensure the operation succeeds
+    assert service.update_project_config(project_id, updated_config) is True
 
-    if response.status_code == 200:
-        print("✓ Configuration updated successfully")
-    else:
-        print(f"✗ Failed to update configuration: {response.status_code}")
-        print(response.text)
-        return False
+    # Reload the project data from disk and validate the nested configuration structure
+    project = service.get_project(project_id)
+    assert project is not None
 
-    # Now fetch the project to verify the config was saved
-    print("\nFetching project to verify configuration...")
-    response = requests.get(f"{API_URL}/projects/{PROJECT_ID}")
+    pipeline_config = project["config"]["pipeline"]
+    assert pipeline_config["do_research"] is False
+    assert pipeline_config["do_generate_article"] is False
+    assert pipeline_config["do_generate_outline"] is True
+    assert pipeline_config["do_polish_article"] is True
 
-    if response.status_code != 200:
-        print(f"✗ Failed to fetch project: {response.status_code}")
-        return False
-
-    project = response.json()
-    config = project.get("config", {})
-
-    # Check if the config is in nested format
-    if "pipeline" in config:
-        print("✓ Configuration is in nested format")
-        pipeline = config.get("pipeline", {})
-        print(f"  do_research: {pipeline.get('do_research')}")
-        print(f"  do_generate_outline: {pipeline.get('do_generate_outline')}")
-        print(f"  do_generate_article: {pipeline.get('do_generate_article')}")
-        print(f"  do_polish_article: {pipeline.get('do_polish_article')}")
-
-        # Verify the values match what we set
-        if (
-            pipeline.get("do_research") == False
-            and pipeline.get("do_generate_article") == False
-        ):
-            print("\n✓ SUCCESS: Configuration persisted correctly!")
-            return True
-        else:
-            print("\n✗ FAILURE: Configuration values don't match what was set")
-            return False
-    else:
-        print("✗ Configuration is still in flat format")
-        print(f"  do_research: {config.get('do_research')}")
-        print(f"  do_generate_article: {config.get('do_generate_article')}")
-        return False
-
-
-if __name__ == "__main__":
-    success = test_config_update()
-    sys.exit(0 if success else 1)
+    retriever_config = project["config"]["retriever"]
+    assert retriever_config["retriever_type"] == "tavily"
+    assert retriever_config["max_search_results"] == 10

--- a/backend/test_google_search.py
+++ b/backend/test_google_search.py
@@ -1,122 +1,161 @@
-#!/usr/bin/env python3
-"""
-Test script to verify Google Search integration in STORM backend.
-"""
+"""Tests for project creation and retriever availability without a running server."""
 
-import requests
-import json
-from datetime import datetime
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any, Dict, List
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.routers import pipeline, projects
+from backend.services.file_service import FileProjectService
+from backend.services.config_service import (
+    ProjectConfig,
+    RetrieverConfig,
+    PipelineConfig,
+)
 
 
-def test_google_search():
-    """Test creating a project with Google Search retriever."""
+class _DummyStormRunner:
+    """Minimal stand-in for the real storm runner used during API tests."""
 
-    base_url = "http://localhost:8000"
+    def __init__(self, file_service: FileProjectService):
+        self.file_service = file_service
 
-    # Check health
-    response = requests.get(f"{base_url}/api/health")
-    print(f"✓ Backend health: {response.json()}")
+    def get_pipeline_status(self, project_id: str) -> Dict[str, Any]:
+        return {
+            "project_id": project_id,
+            "is_running": False,
+            "progress": {"status": "idle", "stage": "idle", "overall_progress": 0.0},
+        }
 
-    # Create project with Google retriever
-    project_data = {
-        "topic": f"Google Search Test - {datetime.now().strftime('%H:%M:%S')}",
-        "title": "Testing Google Search Integration",
-        "config": {
-            "retriever_type": "google",
-            "max_search_results": 5,
-            "llm_model": "gpt-3.5-turbo",
-            "temperature": 0.7,
-            "max_tokens": 1024,
-            "do_research": True,
-            "do_generate_outline": False,
-            "do_generate_article": False,
-            "do_polish_article": False,
+    async def run_mock_pipeline(self, project_id: str, progress_callback=None):
+        return {"status": "mock", "project_id": project_id}
+
+    async def run_pipeline(self, project_id: str, config: ProjectConfig, progress_callback=None):
+        return {"status": "mock", "project_id": project_id}
+
+    def cancel_pipeline(self, project_id: str) -> bool:
+        return False
+
+    def list_running_pipelines(self) -> List[str]:
+        return []
+
+
+def _create_test_client(tmp_path) -> TestClient:
+    """Create a TestClient backed by isolated file storage and dummy runner."""
+
+    storage_dir = tmp_path / "projects"
+    file_service = FileProjectService(base_path=str(storage_dir))
+
+    # Point routers at the isolated services used for testing
+    projects.file_service = file_service
+    pipeline.file_service = file_service
+    pipeline.storm_runner = _DummyStormRunner(file_service)
+
+    return TestClient(app)
+
+
+def _gather_retriever_statuses() -> List[Dict[str, Any]]:
+    """Collect availability information for supported retrievers."""
+
+    retrievers = [
+        (
+            "Google Search",
+            "knowledge_storm.rm",
+            "GoogleSearch",
+            ["GOOGLE_SEARCH_API_KEY", "GOOGLE_CSE_ID"],
+        ),
+        (
+            "Serper",
+            "knowledge_storm.rm",
+            "SerperRM",
+            ["SERPER_API_KEY"],
+        ),
+        (
+            "Tavily",
+            "knowledge_storm.rm",
+            "TavilySearchRM",
+            ["NEXT_PUBLIC_TAVILY_API_KEY"],
+        ),
+        (
+            "DuckDuckGo",
+            "knowledge_storm.rm",
+            "DuckDuckGoSearchRM",
+            [],
+        ),
+    ]
+
+    statuses: List[Dict[str, Any]] = []
+    for name, module_path, attr, required_env in retrievers:
+        installed = False
+        try:
+            module = importlib.import_module(module_path)
+            getattr(module, attr)
+            installed = True
+        except Exception:
+            installed = False
+
+        missing_env = [env for env in required_env if not os.getenv(env)]
+        statuses.append(
+            {
+                "name": name,
+                "installed": installed,
+                "missing_env": missing_env,
+            }
+        )
+
+    return statuses
+
+
+def test_google_retriever_project_creation(tmp_path):
+    """Create a project through the API using the Google retriever configuration."""
+
+    client = _create_test_client(tmp_path)
+
+    health_response = client.get("/api/health")
+    assert health_response.status_code == 200
+    assert health_response.json()["status"] == "healthy"
+
+    config = ProjectConfig(
+        retriever=RetrieverConfig(retriever_type="google", max_search_results=5),
+        pipeline=PipelineConfig(
+            do_research=True,
+            do_generate_outline=False,
+            do_generate_article=False,
+            do_polish_article=False,
+        ),
+    )
+
+    response = client.post(
+        "/api/projects/",
+        json={
+            "topic": "Google Search Test",
+            "title": "Testing Google Search Integration",
+            "config": config.model_dump(),
         },
-    }
+    )
 
-    print("\n📝 Creating project with Google Search retriever...")
-    response = requests.post(f"{base_url}/api/projects", json=project_data)
-
-    if response.status_code == 200:
-        project = response.json()
-        print(f"✓ Project created successfully!")
-        print(f"  ID: {project.get('id')}")
-        print(f"  Topic: {project.get('topic')}")
-        print(f"  Retriever: {project.get('config', {}).get('retriever_type')}")
-        return project
-    else:
-        print(f"✗ Failed to create project: {response.status_code}")
-        print(f"  Response: {response.text}")
-        return None
+    assert response.status_code == 200
+    project = response.json()
+    assert project["config"]["retriever"]["retriever_type"] == "google"
+    assert project["config"]["pipeline"]["do_generate_article"] is False
 
 
-def test_available_retrievers():
-    """Check which retrievers are available."""
+def test_available_retrievers_reports_expected_entries(monkeypatch):
+    """Ensure retriever availability reporting handles missing dependencies gracefully."""
 
-    # Try to import the retrievers to see what's available
-    print("\n🔍 Checking available retrievers...")
+    statuses = _gather_retriever_statuses()
+    names = {status["name"] for status in statuses}
 
-    available = []
+    assert {
+        "Google Search",
+        "Serper",
+        "Tavily",
+        "DuckDuckGo",
+    } == names
 
-    try:
-        from knowledge_storm.rm import GoogleSearch
-        import os
-
-        if os.getenv("GOOGLE_SEARCH_API_KEY") and os.getenv("GOOGLE_CSE_ID"):
-            available.append("✓ Google Search (API key and CSE ID configured)")
-        else:
-            available.append(
-                "○ Google Search (needs GOOGLE_SEARCH_API_KEY and GOOGLE_CSE_ID)"
-            )
-    except ImportError:
-        available.append("✗ Google Search (not installed)")
-
-    try:
-        from knowledge_storm.rm import SerperRM
-        import os
-
-        if os.getenv("SERPER_API_KEY"):
-            available.append("✓ Serper (API key configured)")
-        else:
-            available.append("○ Serper (needs SERPER_API_KEY)")
-    except ImportError:
-        available.append("✗ Serper (not installed)")
-
-    try:
-        from knowledge_storm.rm import TavilySearchRM
-        import os
-
-        if os.getenv("NEXT_PUBLIC_TAVILY_API_KEY"):
-            available.append("✓ Tavily (API key configured)")
-        else:
-            available.append("○ Tavily (needs NEXT_PUBLIC_TAVILY_API_KEY)")
-    except ImportError:
-        available.append("✗ Tavily (not installed)")
-
-    try:
-        from knowledge_storm.rm import DuckDuckGoSearchRM
-
-        available.append("✓ DuckDuckGo (no API key needed)")
-    except ImportError:
-        available.append("✗ DuckDuckGo (not installed)")
-
-    for status in available:
-        print(f"  {status}")
-
-
-if __name__ == "__main__":
-    print("=" * 60)
-    print("STORM Google Search Integration Test")
-    print("=" * 60)
-
-    test_available_retrievers()
-    project = test_google_search()
-
-    if project:
-        print(f"\n✅ Google Search integration is ready!")
-        print(f"\nTo use Google Search:")
-        print(f"1. Add GOOGLE_SEARCH_API_KEY to backend/.env")
-        print(f"2. Add GOOGLE_CSE_ID to backend/.env")
-        print(f"3. Select 'Google Search' in the UI configuration panel")
-
-    print("\n" + "=" * 60)
+    duckduckgo_status = next(status for status in statuses if status["name"] == "DuckDuckGo")
+    assert duckduckgo_status["missing_env"] == []

--- a/backend/test_pipeline_debug.py
+++ b/backend/test_pipeline_debug.py
@@ -5,9 +5,9 @@ import os
 import sys
 import json
 import traceback
-from services.storm_runner import StormRunnerService
-from services.file_service import FileService
-from services.config_service import ProjectConfig
+from backend.services.storm_runner import StormRunnerService
+from backend.services.file_service import FileProjectService
+from backend.services.config_service import ProjectConfig
 import asyncio
 import logging
 
@@ -24,7 +24,7 @@ async def test_pipeline():
 
     try:
         # Initialize services
-        file_service = FileService()
+        file_service = FileProjectService()
         storm_runner = StormRunnerService(file_service)
 
         # Get project
@@ -33,12 +33,12 @@ async def test_pipeline():
             logger.error(f"Project {project_id} not found")
             return
 
-        logger.info(f"Project found: {project.title}")
-        logger.info(f"Topic: {project.topic}")
+        logger.info(f"Project found: {project['title']}")
+        logger.info(f"Topic: {project['topic']}")
 
         # Load config
         config_path = os.path.join(
-            file_service.get_project_dir(project_id), "config.json"
+            file_service.projects_dir, project_id, "config.json"
         )
 
         with open(config_path, "r") as f:


### PR DESCRIPTION
## Summary
- switch backend modules to use package-relative imports so pytest can import them from the repo root
- replace HTTP-based backend tests with service- and TestClient-driven checks that run offline
- update the pipeline debug helper to reference the backend services package correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0c12b2a808332b36232a449f2e1f6